### PR TITLE
Add CL args to exp_0 and make WandB optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ We built six different models based on CLIP from scratch using PyTorch. The mode
 0. Pre-trained ResNet50, Hugging Face DistillBERT, Flickr30k
 1. Self-trained ResNet50 on CIFAR-10, Hugging Face DistillBert, Flickr30k
 2. Pre-trained ResNet50, Hugging Face BERT, Flickr30k
-3. Pre-trained ResNet50, Hugging Face DistillBERT, Train on Flickr30k, Train on Flickr8k
-4. Pre-trained ResNet50, Hugging Face DistillBERT, Train on Flickr8k, Train on Flickr30k
+3. Pre-trained ResNet50, Hugging Face DistillBERT, Train on Flickr30k, Test on Flickr8k
+4. Pre-trained ResNet50, Hugging Face DistillBERT, Train on Flickr8k, Test on Flickr30k
 5. Pre-trained ResNet50, Hugging Face DistillBERT, Flickr30k + Flickr8k
 5. Pre-trained ResNet50, Hugging Face DistillBERT, Increased “temperature”
 ```
@@ -36,6 +36,8 @@ We evaluated the quality of the machine-generated captions using the [BLEU metri
 |       ├── flickr30k 
 |           ├── results.csv # Raw flickr30k captions
 |           ├── Images/ # Folder of flickr30k images
+|       ├── combined/
+|           ├── Images/ # Folder of combined flickr8k and flickr30k images
 ├── models/ # Where lcoal PyTorch model checkpoints are stored
 ├── notebooks/ # Jupyter noteboks
 |   ├── bleu.ipynb # Evaluting quality of machine-generated captions using BLEU metric

--- a/scripts/exp_0.py
+++ b/scripts/exp_0.py
@@ -16,8 +16,7 @@ from train_eval_utils import train_epoch, valid_epoch
 def main():
     config = default_config
     device = config['device']
-    print(f'{project_name=}\n{exp_name=}\n{device=}')
-    print(f'{config=}')
+    print(f'{config=}\n{device=}')
 
     preprocess(config['raw_file_path'], 1)
     train_df, valid_df = make_train_valid_dfs(config["clean_file_path"], 0.8)
@@ -26,6 +25,7 @@ def main():
     valid_loader = build_loaders(valid_df, tokenizer, mode="valid", config=config)
 
     if entity is not None and project_name is not None and exp_name is not None:
+        print(f'{entity=}\n{project_name=}\n{exp_name=}')
         # run = wandb.init()
         # artifact = run.use_artifact(f'{entity}/{project_name}/{exp_name}:latest',
         #                             type='model')
@@ -40,9 +40,9 @@ def main():
 
     params = [
         {"params": model.image_encoder.parameters(),
-        "lr": config['image_encoder_lr']},
+            "lr": config['image_encoder_lr']},
         {"params": model.text_encoder.parameters(),
-        "lr": config['text_encoder_lr']},
+            "lr": config['text_encoder_lr']},
         {"params": itertools.chain(
             model.image_projection.parameters(), model.text_projection.parameters()
         ), "lr": config['projection_head_lr'],
@@ -60,7 +60,7 @@ def main():
         print(f"Epoch: {epoch + 1}")
         model.train()
         train_loss = train_epoch(model, train_loader, optimizer, lr_scheduler,
-                                step, device)
+                                 step, device)
         model.eval()
         with torch.no_grad():
             valid_loss = valid_epoch(model, valid_loader, device)
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     )
     parser.add_argument(
         "--project_name",
-        default='image-captioning-CLIP',
+        default=None,
         type=str,
         help="WandB project name",
     )

--- a/scripts/exp_0.py
+++ b/scripts/exp_0.py
@@ -1,3 +1,4 @@
+import argparse
 import itertools
 import torch
 import wandb
@@ -12,67 +13,95 @@ from clip_utils import CLIPModel
 from train_eval_utils import train_epoch, valid_epoch
 
 
-entity = 'image-captioning-clip'
-project_name = 'image-captioning-CLIP'
-exp_name = 'exp_0'
-config = default_config
-device = config['device']
-print(f'{project_name=}\n{exp_name=}\n{device=}')
-print(f'{config=}')
+def main():
+    config = default_config
+    device = config['device']
+    print(f'{project_name=}\n{exp_name=}\n{device=}')
+    print(f'{config=}')
 
-preprocess(config['raw_file_path'], 1)
-train_df, valid_df = make_train_valid_dfs(config["clean_file_path"], 0.8)
-tokenizer = DistilBertTokenizer.from_pretrained(config['text_tokenizer'])
-train_loader = build_loaders(train_df, tokenizer, mode="train", config=config)
-valid_loader = build_loaders(valid_df, tokenizer, mode="valid", config=config)
+    preprocess(config['raw_file_path'], 1)
+    train_df, valid_df = make_train_valid_dfs(config["clean_file_path"], 0.8)
+    tokenizer = DistilBertTokenizer.from_pretrained(config['text_tokenizer'])
+    train_loader = build_loaders(train_df, tokenizer, mode="train", config=config)
+    valid_loader = build_loaders(valid_df, tokenizer, mode="valid", config=config)
 
-# run = wandb.init()
-# artifact = run.use_artifact(f'{entity}/{project_name}/{exp_name}:latest',
-#                             type='model')
-# artifact_dir = artifact.download()
-# run.finish()
+    if entity is not None and project_name is not None and exp_name is not None:
+        # run = wandb.init()
+        # artifact = run.use_artifact(f'{entity}/{project_name}/{exp_name}:latest',
+        #                             type='model')
+        # artifact_dir = artifact.download()
+        # run.finish()
 
-run = wandb.init(entity=entity, project=project_name, config=config)
+        run = wandb.init(entity=entity, project=project_name, config=config)
 
-model = CLIPModel(config)
-# model.load_state_dict(torch.load(f'{artifact_dir}/{exp_name}.pt'))
-model.to(device)
+    model = CLIPModel(config)
+    # model.load_state_dict(torch.load(f'{artifact_dir}/{exp_name}.pt'))
+    model.to(device)
 
-params = [
-    {"params": model.image_encoder.parameters(),
-     "lr": config['image_encoder_lr']},
-    {"params": model.text_encoder.parameters(),
-     "lr": config['text_encoder_lr']},
-    {"params": itertools.chain(
-        model.image_projection.parameters(), model.text_projection.parameters()
-    ), "lr": config['projection_head_lr'],
-        "weight_decay": config["weight_decay"]
-    }
-]
-optimizer = torch.optim.AdamW(params, weight_decay=0.)
-lr_scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
-    optimizer, mode="min", patience=config['patience'], factor=config['factor']
-)
-step = "epoch"
+    params = [
+        {"params": model.image_encoder.parameters(),
+        "lr": config['image_encoder_lr']},
+        {"params": model.text_encoder.parameters(),
+        "lr": config['text_encoder_lr']},
+        {"params": itertools.chain(
+            model.image_projection.parameters(), model.text_projection.parameters()
+        ), "lr": config['projection_head_lr'],
+            "weight_decay": config["weight_decay"]
+        }
+    ]
+    optimizer = torch.optim.AdamW(params, weight_decay=0.)
+    lr_scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
+        optimizer, mode="min", patience=config['patience'], factor=config['factor']
+    )
+    step = "epoch"
 
-best_loss = float('inf')
-for epoch in range(config['epochs']):
-    print(f"Epoch: {epoch + 1}")
-    model.train()
-    train_loss = train_epoch(model, train_loader, optimizer, lr_scheduler,
-                             step, device)
-    model.eval()
-    with torch.no_grad():
-        valid_loss = valid_epoch(model, valid_loader, device)
+    best_loss = float('inf')
+    for epoch in range(config['epochs']):
+        print(f"Epoch: {epoch + 1}")
+        model.train()
+        train_loss = train_epoch(model, train_loader, optimizer, lr_scheduler,
+                                step, device)
+        model.eval()
+        with torch.no_grad():
+            valid_loss = valid_epoch(model, valid_loader, device)
 
-    if valid_loss.avg < best_loss:
-        best_loss = valid_loss.avg
-        torch.save(model.state_dict(), f'../models/{exp_name}.pt')
-        artifact = wandb.Artifact(exp_name, type='model')
-        artifact.add_file(f'../models/{exp_name}.pt')
-        run.log_artifact(artifact)
-        print("Saved Best Model!")
+        if valid_loss.avg < best_loss:
+            best_loss = valid_loss.avg
+            torch.save(model.state_dict(), f'../models/{exp_name}.pt')
+            if run is not None:
+                artifact = wandb.Artifact(exp_name, type='model')
+                artifact.add_file(f'../models/{exp_name}.pt')
+                run.log_artifact(artifact)
+            print("Saved Best Model!")
 
-    lr_scheduler.step(valid_loss.avg)
+        lr_scheduler.step(valid_loss.avg)
 
-run.finish()
+    if run is not None:
+        run.finish()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--entity",
+        default=None,
+        type=str,
+        help="WandB entity",
+    )
+    parser.add_argument(
+        "--project_name",
+        default='image-captioning-CLIP',
+        type=str,
+        help="WandB project name",
+    )
+    parser.add_argument(
+        "--exp_name",
+        default=None,
+        type=str,
+        help="WandB artifact name",
+    )
+    args = parser.parse_args()
+    entity = args.entity
+    project_name = args.project_name
+    exp_name = args.exp_name
+    main()


### PR DESCRIPTION
Python experiment scripts can now be run like:
```python3 exp_0.py --entity image-captioning-clip --project_name image-captioning-CLIP --exp_name exp_0``` with WandB
or:
```python3 exp_0.py``` without WandB